### PR TITLE
Add a default implementation for #custom_damage:death

### DIFF
--- a/data/custom_damage/functions/default_kill.mcfunction
+++ b/data/custom_damage/functions/default_kill.mcfunction
@@ -1,0 +1,3 @@
+# By default, kill the target using the normal /kill command
+# This behavior can be changed by overriding the #custom_damage:death function tag
+kill @s

--- a/data/custom_damage/tags/functions/death.json
+++ b/data/custom_damage/tags/functions/death.json
@@ -1,0 +1,1 @@
+{"values":["custom_damage:default_kill"]}


### PR DESCRIPTION
I agree that people might want to change how death is handled, and letting them override a function tag is a good way of doing that. But I figure people shouldn't *have* to do that, if all they want is the standard `/kill` experience.

This PR adds a default implementation of the `#custom_damage:death` function tag, which just runs `kill @s`. People who want to implement their own death system can easily use `"replace": true` in their tag JSON, and people who don't, don't have to.